### PR TITLE
[체리/#30] 5주차 구현

### DIFF
--- a/app/src/main/java/com/example/umc_8th/MainActivity_2nd.kt
+++ b/app/src/main/java/com/example/umc_8th/MainActivity_2nd.kt
@@ -5,6 +5,7 @@ import com.example.umc_8th.MusicPlayerState
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
+import android.widget.SeekBar
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -19,6 +20,8 @@ import com.example.umc_8th.databinding.ActivityMain2ndBinding
 class MainActivity_2nd : AppCompatActivity(){
 
 
+
+
     private lateinit var mBinding : ActivityMain2ndBinding
     val TAG: String = "로그"
 
@@ -27,6 +30,10 @@ class MainActivity_2nd : AppCompatActivity(){
             if (isPlaying) R.drawable.btn_miniplay_pause
             else R.drawable.btn_miniplayer_play
         )
+    }
+
+    private val progressListener: (Int) -> Unit = { progress ->
+        mBinding.timeSeekBar.progress = progress
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -42,13 +49,38 @@ class MainActivity_2nd : AppCompatActivity(){
         //바텀네비게이션뷰와 묶어줌
         NavigationUI.setupWithNavController(mBinding.myBtmNav, navController)
 
-//       // miniPlayer 버튼 클릭 시 토글, +곡 세팅 안되면 버튼 비활성
-//        mBinding.miniPlayBtn.setOnClickListener {
-//            val isPlaying = it.tag == "playing"
-//            setMiniPlayerButtonState(!isPlaying)
-//        }
-
         MusicPlayerState.addPlayListener(playStateListener)
+
+
+        mBinding.miniPlayBtn.setOnClickListener {
+            MusicPlayerState.togglePlay()
+        }
+
+        //진행도 리스너
+        MusicPlayerState.addProgressListener(progressListener)
+
+        MusicPlayerState.addProgressListener { progress ->
+            mBinding.timeSeekBar.progress = progress
+        }
+
+
+
+        mBinding.timeSeekBar.thumb = null
+        mBinding.timeSeekBar.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
+            override fun onProgressChanged(seekBar: SeekBar?, progress: Int, fromUser: Boolean) {
+                if (fromUser) {
+                    MusicPlayerState.setProgress(progress)
+                }
+            }
+
+            override fun onStartTrackingTouch(seekBar: SeekBar?) {
+                // 필요하다면 일시정지 시킬 수도 있음
+            }
+
+            override fun onStopTrackingTouch(seekBar: SeekBar?) {
+                // 드래그가 끝났을 때, 자동 진행은 그대로 유지됨
+            }
+        })
 
         mBinding.miniPlayBtn.setOnClickListener {
             MusicPlayerState.togglePlay()
@@ -72,6 +104,8 @@ class MainActivity_2nd : AppCompatActivity(){
 
         mBinding.miniPlayer.visibility = View.VISIBLE
     }
+
+
 
     override fun onDestroy() {
         super.onDestroy()

--- a/app/src/main/java/com/example/umc_8th/MusicPlayerState.kt
+++ b/app/src/main/java/com/example/umc_8th/MusicPlayerState.kt
@@ -76,36 +76,3 @@ object MusicPlayerState {
         progressListeners.remove(listener)
     }
 }
-
-// 파일: MusicPlayerState.kt
-//
-//object MusicPlayerState {
-//    var isPlaying: Boolean = false
-//        private set
-//
-//    private val listeners = mutableListOf<(Boolean) -> Unit>()
-//
-//    fun togglePlay() {
-//        isPlaying = !isPlaying
-//        notifyListeners()
-//    }
-//
-//    fun setPlayState(playing: Boolean) {
-//        isPlaying = playing
-//        notifyListeners()
-//    }
-//
-//    private fun notifyListeners() {
-//        listeners.forEach { it(isPlaying) }
-//    }
-//
-//    fun addListener(listener: (Boolean) -> Unit) {
-//        listeners.add(listener)
-//        listener(isPlaying) // 초기 상태도 반영
-//    }
-//
-//    fun removeListener(listener: (Boolean) -> Unit) {
-//        listeners.remove(listener)
-//    }
-//}
-//

--- a/app/src/main/java/com/example/umc_8th/SongActivity.kt
+++ b/app/src/main/java/com/example/umc_8th/SongActivity.kt
@@ -52,6 +52,9 @@ class SongActivity :AppCompatActivity(){
             binding.timeSeekBar.progress = progress
         }
 
+        binding.timeSeekBar.thumb = null
+
+
 
         //사용자 클릭에 반응
         binding.timeSeekBar.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {

--- a/app/src/main/res/drawable/seekbar_progress.xml
+++ b/app/src/main/res/drawable/seekbar_progress.xml
@@ -1,0 +1,16 @@
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:id="@android:id/background">
+        <shape android:shape="rectangle">
+            <solid android:color="#D3D3D3"/>
+        </shape>
+    </item>
+
+    <item android:id="@android:id/progress">
+        <clip>
+            <shape android:shape="rectangle">
+                <solid android:color="@color/purple_700"/>
+                <corners android:radius="2dp"/>
+            </shape>
+        </clip>
+    </item>
+</layer-list>

--- a/app/src/main/res/drawable/transparent_thumb.xml
+++ b/app/src/main/res/drawable/transparent_thumb.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android">
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
     <solid android:color="@android:color/transparent" />
 </shape>

--- a/app/src/main/res/layout/activity_main_2nd.xml
+++ b/app/src/main/res/layout/activity_main_2nd.xml
@@ -23,6 +23,17 @@
         app:navGraph = "@navigation/nav_graph"
         />
 
+    <SeekBar
+        android:id="@+id/timeSeekBar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:max="100"
+        android:progress="0"
+        app:layout_constraintBottom_toTopOf="@id/miniPlayer"
+        tools:layout_editor_absoluteX="16dp"
+        android:progressDrawable="@drawable/seekbar_progress"/>
+
+
 
     <LinearLayout
         android:id="@+id/miniPlayer"

--- a/app/src/main/res/layout/activity_song.xml
+++ b/app/src/main/res/layout/activity_song.xml
@@ -50,11 +50,11 @@
         android:id="@+id/timeSeekBar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_margin="16dp"
         android:max="100"
         android:progress="0"
         app:layout_constraintBottom_toTopOf="@id/songPlayBar"
-        tools:layout_editor_absoluteX="16dp"/>
+        android:progressDrawable="@drawable/seekbar_progress"/>
+
 
     <LinearLayout
         android:id="@+id/songPlayBar"
@@ -176,20 +176,20 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_begin="20dp" />
+        app:layout_constraintGuide_begin="-34dp" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guideline2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_begin="20dp" />
+        app:layout_constraintGuide_begin="-17dp" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guideline3"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_begin="20dp" />
+        app:layout_constraintGuide_begin="-8dp" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
# 📌 생명주기 및 스레드
> Song과 Main에 seekbar를 구현하고, 진행시간이 반영되도록 함

## ✅ 변경 사항
> 이번 PR에서 변경된 내용을 간략히 정리해주세요.
- [1] SongActiviry에 스레드 재시작 구현
- [2] MainActivity에 Song과 동일한 seekbar구현
 -> 단순 형태만 같은 뿐 아니라 기능까지 동일하도록 구현(ex, Song에서 멈추면 Main에서도 멈추고 이미지버튼도 교체되도록!)


## 📷 영상 및 스크린샷
[Screen_recording_20250429_154129.webm](https://github.com/user-attachments/assets/5c350f92-3cdb-4728-95a9-9f90523b31d0)


## 🔗 알게 된 사항
> Activity와 Fragment에서 생면주기를 다루는 데에 차이를 조금 더 이해하게 됨. 
리사이클러뷰나 스레드 등을 구현할 때 kt파일의 어떤 생명주기에서 초기화하고, 사용하고 등에 대해 더 알게 됨


## 📝 질문 사항
> seekbar 디자인부분!!
레이아웃 면에서는 꽉 차는데 왜 회색 bar가 끝까지 안차는거지 ㅠ
