### PR TITLE
[cherry/#37] 6주차 구현 

### DIFF
--- a/app/src/main/java/com/example/umc_8th/MainActivity_2nd.kt
+++ b/app/src/main/java/com/example/umc_8th/MainActivity_2nd.kt
@@ -20,8 +20,6 @@ import com.example.umc_8th.databinding.ActivityMain2ndBinding
 class MainActivity_2nd : AppCompatActivity(){
 
 
-
-
     private lateinit var mBinding : ActivityMain2ndBinding
     val TAG: String = "로그"
 
@@ -32,6 +30,7 @@ class MainActivity_2nd : AppCompatActivity(){
         )
     }
 
+    //seekbar리스너 변수 설정
     private val progressListener: (Int) -> Unit = { progress ->
         mBinding.timeSeekBar.progress = progress
     }

--- a/app/src/main/java/com/example/umc_8th/MainActivity_2nd.kt
+++ b/app/src/main/java/com/example/umc_8th/MainActivity_2nd.kt
@@ -6,19 +6,13 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import android.widget.SeekBar
-import androidx.activity.ComponentActivity
-import androidx.activity.compose.setContent
-import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.NavigationUI
-import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.RecyclerView
 import com.example.umc_8th.databinding.ActivityMain2ndBinding
 
 
 class MainActivity_2nd : AppCompatActivity(){
-
 
     private lateinit var mBinding : ActivityMain2ndBinding
     val TAG: String = "로그"
@@ -49,7 +43,6 @@ class MainActivity_2nd : AppCompatActivity(){
         NavigationUI.setupWithNavController(mBinding.myBtmNav, navController)
 
         MusicPlayerState.addPlayListener(playStateListener)
-
 
         mBinding.miniPlayBtn.setOnClickListener {
             MusicPlayerState.togglePlay()
@@ -111,89 +104,3 @@ class MainActivity_2nd : AppCompatActivity(){
         MusicPlayerState.removePlayListener(playStateListener)
     }
 }
-
-
-//package com.example.umc_8th
-//
-//import com.example.umc_8th.MusicPlayerState
-//
-//import android.content.Intent
-//import android.os.Bundle
-//import android.view.View
-//import androidx.activity.ComponentActivity
-//import androidx.activity.compose.setContent
-//import androidx.activity.enableEdgeToEdge
-//import androidx.appcompat.app.AppCompatActivity
-//import androidx.navigation.fragment.NavHostFragment
-//import androidx.navigation.ui.NavigationUI
-//import androidx.recyclerview.widget.LinearLayoutManager
-//import androidx.recyclerview.widget.RecyclerView
-//import com.example.umc_8th.databinding.ActivityMain2ndBinding
-//
-//
-//class MainActivity_2nd : AppCompatActivity(){
-//
-//
-//    private lateinit var mBinding : ActivityMain2ndBinding
-//    val TAG: String = "로그"
-//
-//    override fun onCreate(savedInstanceState: Bundle?) {
-//        super.onCreate(savedInstanceState)
-//
-//        mBinding = ActivityMain2ndBinding.inflate(layoutInflater)
-//
-//        setContentView(mBinding.root)
-//
-//        val navHostFragment = supportFragmentManager.findFragmentById(R.id.my_nav_host) as NavHostFragment
-//
-//        //네비게이션을 컨트롤러
-//        val navController = navHostFragment.navController
-//        //바텀네비게이션뷰와 묶어줌
-//        NavigationUI.setupWithNavController(mBinding.myBtmNav, navController)
-//
-//       // miniPlayer 버튼 클릭 시 토글, +곡 세팅 안되면 버튼 비활성
-//        mBinding.miniPlayBtn.setOnClickListener {
-//            val isPlaying = it.tag == "playing"
-//            setMiniPlayerButtonState(!isPlaying)
-//        }
-//
-//        mBinding.miniPlayer.setOnClickListener {
-//            val intent = Intent(this, SongActivity::class.java).apply {
-//                putExtra("songTitle", mBinding.miniSongTitle.text.toString())
-//                putExtra("songArtist", mBinding.miniSongArtist.text.toString())
-//                //이미지 추가로 넣기(추후)
-//            }
-//            startActivity(intent)
-//        }
-//
-//
-//
-//    }
-//
-//    private fun setMiniPlayerButtonState(isPlaying: Boolean) {
-//        if (isPlaying) {
-//            mBinding.miniPlayBtn.setImageResource(R.drawable.btn_miniplay_pause)
-//            mBinding.miniPlayBtn.tag = "playing"
-//        } else {
-//            mBinding.miniPlayBtn.setImageResource(R.drawable.btn_miniplayer_play)
-//            mBinding.miniPlayBtn.tag = "paused"
-//        }
-//    }
-//
-//    fun updateMiniPlayer(title: String, artist: String, isPlaying: Boolean) {
-//        mBinding.miniSongTitle.text = title
-//        mBinding.miniSongArtist.text = artist
-//
-//        if (isPlaying) {
-//            mBinding.miniPlayBtn.setImageResource(R.drawable.btn_miniplay_pause)
-//            mBinding.miniPlayBtn.tag = "playing"
-//        } else {
-//            mBinding.miniPlayBtn.setImageResource(R.drawable.btn_miniplayer_play)
-//            mBinding.miniPlayBtn.tag = "paused"
-//        }
-//
-//        mBinding.miniPlayer.visibility = View.VISIBLE
-//    }
-//
-//
-//}

--- a/app/src/main/java/com/example/umc_8th/SavedData.kt
+++ b/app/src/main/java/com/example/umc_8th/SavedData.kt
@@ -1,0 +1,7 @@
+package com.example.umc_8th
+
+data class SavedData (
+    val savedImg: Int,
+    val savedName: String,
+    val savedArtist: String
+)

--- a/app/src/main/java/com/example/umc_8th/adapter/AlbumAdapter.kt
+++ b/app/src/main/java/com/example/umc_8th/adapter/AlbumAdapter.kt
@@ -7,29 +7,50 @@ import com.example.umc_8th.AlbumItem
 import com.example.umc_8th.databinding.AlbumRecyclerviewBinding
 
 class AlbumAdapter(private val albumList: List<AlbumItem>,
+                   private val onPlayClick: (String, String) -> Unit,
                    private val onItemClick: (AlbumItem) -> Unit ) :
     RecyclerView.Adapter<AlbumAdapter.AlbumViewHolder>() {
 
-    inner class AlbumViewHolder(private val binding: AlbumRecyclerviewBinding) : RecyclerView.ViewHolder(binding.root) {
-        fun bind(album: AlbumItem) {
-            binding.albumImg.setImageResource(album.albumImage)
-            binding.albumName.text = album.albumName
-            binding.artistName.text = album.artistName
-
-            binding.root.setOnClickListener {
-                onItemClick(album) // 클릭 시 함수 실행
-            }
-        }
-    }
+    inner class AlbumViewHolder(val binding: AlbumRecyclerviewBinding) :
+        RecyclerView.ViewHolder(binding.root)
+//    {
+//        fun bind(album: AlbumItem) {
+//            binding.albumImg.setImageResource(album.albumImage)
+//            binding.albumName.text = album.albumName
+//            binding.artistName.text = album.artistName
+//
+//            binding.root.setOnClickListener {
+//                onItemClick(album) // 클릭 시 함수 실행
+//            }
+//        }
+//    }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): AlbumViewHolder {
-        val binding = AlbumRecyclerviewBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        val binding =
+            AlbumRecyclerviewBinding.inflate(LayoutInflater.from(parent.context), parent, false)
         return AlbumViewHolder(binding)
     }
 
     override fun onBindViewHolder(holder: AlbumViewHolder, position: Int) {
-        holder.bind(albumList[position])
-    }
+        val album = albumList[position]
 
+        with(holder.binding) {
+            albumImg.setImageResource(album.albumImage)
+            albumName.text = album.albumName
+            artistName.text = album.artistName
+
+            // 기존 아이템 전체 클릭
+            root.setOnClickListener {
+                onItemClick(album)
+            }
+
+            // 🎯 play_btn 클릭 시 제목과 가수만 전달
+            playBtn.setOnClickListener {
+                onPlayClick(album.albumName, album.artistName)
+            }
+        }
+
+
+    }
     override fun getItemCount(): Int = albumList.size
 }

--- a/app/src/main/java/com/example/umc_8th/adapter/AlbumAdapter.kt
+++ b/app/src/main/java/com/example/umc_8th/adapter/AlbumAdapter.kt
@@ -1,8 +1,9 @@
-package com.example.umc_8th
+package com.example.umc_8th.adapter
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
+import com.example.umc_8th.AlbumItem
 import com.example.umc_8th.databinding.AlbumRecyclerviewBinding
 
 class AlbumAdapter(private val albumList: List<AlbumItem>,

--- a/app/src/main/java/com/example/umc_8th/adapter/BannerAdapter.kt
+++ b/app/src/main/java/com/example/umc_8th/adapter/BannerAdapter.kt
@@ -1,7 +1,8 @@
-package com.example.umc_8th
+package com.example.umc_8th.adapter
 
 import androidx.fragment.app.Fragment
 import androidx.viewpager2.adapter.FragmentStateAdapter
+import com.example.umc_8th.BannerItem
 import com.example.umc_8th.fragment.BannerFragment
 
 class BannerAdapter(fragment: Fragment, private val banners: List<BannerItem>) : FragmentStateAdapter(fragment) {

--- a/app/src/main/java/com/example/umc_8th/adapter/BannerAlbumAdapter.kt
+++ b/app/src/main/java/com/example/umc_8th/adapter/BannerAlbumAdapter.kt
@@ -1,8 +1,9 @@
-package com.example.umc_8th
+package com.example.umc_8th.adapter
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
+import com.example.umc_8th.BannerAlbumItem
 import com.example.umc_8th.databinding.BannerAlbumRecyclerviewBinding
 
 class BannerAlbumAdapter(

--- a/app/src/main/java/com/example/umc_8th/adapter/BannerAlbumAdapter.kt
+++ b/app/src/main/java/com/example/umc_8th/adapter/BannerAlbumAdapter.kt
@@ -37,37 +37,3 @@ class BannerAlbumAdapter(
 
     override fun getItemCount(): Int = items.size
 }
-
-//
-//class BannerAlbumAdapter(
-//    private val itemList: List<BannerItem>
-//) : RecyclerView.Adapter<BannerAlbumAdapter.BannerViewHolder>() {
-//
-//    inner class BannerViewHolder(val binding: BannerAlbumRecyclerviewBinding) :
-//        RecyclerView.ViewHolder(binding.root)
-//
-//    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): BannerViewHolder {
-//        val binding = BannerAlbumRecyclerviewBinding.inflate(
-//            LayoutInflater.from(parent.context), parent, false
-//        )
-//        return BannerViewHolder(binding)
-//    }
-//
-//    override fun onBindViewHolder(holder: BannerViewHolder, position: Int) {
-//        val item = itemList[position]
-//
-//        holder.binding.apply {
-//            // item_banner_album.xml에 맞게 데이터 바인딩
-//            bannerAlbumImg.setImageResource(item.imageRes)
-//            bannerAlbumSongName.text = item.song1Title
-//            bannerAlbumSongArtist.text = item.song1Artist
-//        }
-//
-////        holder.binding.bannerAlbumImg.setImageResource(item.imageRes)
-////        holder.binding.bannerAlbumSongName.text = item.song1Title
-////        holder.binding.bannerAlbumSongArtist.text = item.song1Artist
-//
-//    }
-//
-//    override fun getItemCount(): Int = itemList.size
-//}

--- a/app/src/main/java/com/example/umc_8th/adapter/NewSongAdapter.kt
+++ b/app/src/main/java/com/example/umc_8th/adapter/NewSongAdapter.kt
@@ -1,18 +1,19 @@
-package com.example.umc_8th
+package com.example.umc_8th.adapter
 
 import androidx.fragment.app.Fragment
 import androidx.viewpager2.adapter.FragmentStateAdapter
-import com.example.umc_8th.fragment.FileFragment
-import com.example.umc_8th.fragment.SavedFragment
+import com.example.umc_8th.fragment.ListedFragment
+import com.example.umc_8th.fragment.InfoFragment
 
-class StorageAdapter(fragment: Fragment) : FragmentStateAdapter(fragment) {
+class NewSongAdapter(fragment: Fragment): FragmentStateAdapter(fragment) {
     override fun getItemCount(): Int = 2  // 탭 개수 (저장한 곡, 음악 파일)
 
     override fun createFragment(position: Int): Fragment {
         return when (position) {
-            0 -> SavedFragment()  // 저장한 곡 Fragment
-            1 -> FileFragment()  // 음악 파일 Fragment
+            0 -> ListedFragment()  // 저장한 곡 Fragment
+            1 -> InfoFragment()  // 음악 파일 Fragment
             else -> throw IllegalStateException("Unexpected position $position")
         }
     }
+
 }

--- a/app/src/main/java/com/example/umc_8th/adapter/SavedAdapter.kt
+++ b/app/src/main/java/com/example/umc_8th/adapter/SavedAdapter.kt
@@ -6,19 +6,34 @@ import androidx.recyclerview.widget.RecyclerView
 import com.example.umc_8th.SavedData
 import com.example.umc_8th.databinding.ItemSavedBinding
 
+class SavedAdapter(
+    private val savedList: MutableList<SavedData>,
+    private val onItemClickListener: OnItemClickListener
+) : RecyclerView.Adapter<SavedAdapter.SavedViewHolder>() {
 
+    interface OnItemClickListener {
+        fun onItemClick(position: Int)
+    }
 
-class SavedAdapter(private val savedList: List<SavedData>): RecyclerView.Adapter<SavedAdapter.SavedViewHolder>() {
-    inner class SavedViewHolder(private val binding: ItemSavedBinding):RecyclerView.ViewHolder(binding.root){
-        fun bind(savedData: SavedData){
+    inner class SavedViewHolder(private val binding: ItemSavedBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(savedData: SavedData) {
             binding.savedImg.setImageResource(savedData.savedImg)
             binding.savedName.text = savedData.savedName
             binding.savedArtist.text = savedData.savedArtist
+
+            binding.moreBtn.setOnClickListener {
+                val pos = bindingAdapterPosition
+                if (pos != RecyclerView.NO_POSITION) {
+                    onItemClickListener.onItemClick(pos)
+                }
+            }
         }
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SavedViewHolder {
-        val binding =ItemSavedBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        val binding = ItemSavedBinding.inflate(LayoutInflater.from(parent.context), parent, false)
         return SavedViewHolder(binding)
     }
 
@@ -27,4 +42,9 @@ class SavedAdapter(private val savedList: List<SavedData>): RecyclerView.Adapter
     }
 
     override fun getItemCount(): Int = savedList.size
+
+    fun removeItem(position: Int) {
+        savedList.removeAt(position)
+        notifyItemRemoved(position)
+    }
 }

--- a/app/src/main/java/com/example/umc_8th/adapter/SavedAdapter.kt
+++ b/app/src/main/java/com/example/umc_8th/adapter/SavedAdapter.kt
@@ -43,8 +43,12 @@ class SavedAdapter(
 
     override fun getItemCount(): Int = savedList.size
 
-    fun removeItem(position: Int) {
-        savedList.removeAt(position)
-        notifyItemRemoved(position)
+
+    fun updateList(newList: List<SavedData>) {
+        savedList.clear()
+        savedList.addAll(newList)
+        notifyDataSetChanged()
+
     }
+
 }

--- a/app/src/main/java/com/example/umc_8th/adapter/SavedAdapter.kt
+++ b/app/src/main/java/com/example/umc_8th/adapter/SavedAdapter.kt
@@ -1,0 +1,30 @@
+package com.example.umc_8th.adapter
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.example.umc_8th.SavedData
+import com.example.umc_8th.databinding.ItemSavedBinding
+
+
+
+class SavedAdapter(private val savedList: List<SavedData>): RecyclerView.Adapter<SavedAdapter.SavedViewHolder>() {
+    inner class SavedViewHolder(private val binding: ItemSavedBinding):RecyclerView.ViewHolder(binding.root){
+        fun bind(savedData: SavedData){
+            binding.savedImg.setImageResource(savedData.savedImg)
+            binding.savedName.text = savedData.savedName
+            binding.savedArtist.text = savedData.savedArtist
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SavedViewHolder {
+        val binding =ItemSavedBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return SavedViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: SavedViewHolder, position: Int) {
+        holder.bind(savedList[position])
+    }
+
+    override fun getItemCount(): Int = savedList.size
+}

--- a/app/src/main/java/com/example/umc_8th/adapter/StateAdapter.kt
+++ b/app/src/main/java/com/example/umc_8th/adapter/StateAdapter.kt
@@ -1,4 +1,4 @@
-package com.example.umc_8th
+package com.example.umc_8th.adapter
 
 import android.os.Bundle
 import androidx.fragment.app.Fragment

--- a/app/src/main/java/com/example/umc_8th/adapter/StorageAdapter.kt
+++ b/app/src/main/java/com/example/umc_8th/adapter/StorageAdapter.kt
@@ -1,19 +1,18 @@
-package com.example.umc_8th
+package com.example.umc_8th.adapter
 
 import androidx.fragment.app.Fragment
 import androidx.viewpager2.adapter.FragmentStateAdapter
-import com.example.umc_8th.fragment.ListedFragment
-import com.example.umc_8th.fragment.InfoFragment
+import com.example.umc_8th.fragment.FileFragment
+import com.example.umc_8th.fragment.SavedFragment
 
-class NewSongAdapter(fragment: Fragment): FragmentStateAdapter(fragment) {
+class StorageAdapter(fragment: Fragment) : FragmentStateAdapter(fragment) {
     override fun getItemCount(): Int = 2  // 탭 개수 (저장한 곡, 음악 파일)
 
     override fun createFragment(position: Int): Fragment {
         return when (position) {
-            0 -> ListedFragment()  // 저장한 곡 Fragment
-            1 -> InfoFragment()  // 음악 파일 Fragment
+            0 -> SavedFragment()  // 저장한 곡 Fragment
+            1 -> FileFragment()  // 음악 파일 Fragment
             else -> throw IllegalStateException("Unexpected position $position")
         }
     }
-
 }

--- a/app/src/main/java/com/example/umc_8th/fragment/AlbumFragment.kt
+++ b/app/src/main/java/com/example/umc_8th/fragment/AlbumFragment.kt
@@ -5,7 +5,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import com.example.umc_8th.NewSongAdapter
+import com.example.umc_8th.adapter.NewSongAdapter
 import com.example.umc_8th.R
 import com.example.umc_8th.databinding.FragmentAlbumBinding
 import com.google.android.material.tabs.TabLayoutMediator

--- a/app/src/main/java/com/example/umc_8th/fragment/AlbumFragment.kt
+++ b/app/src/main/java/com/example/umc_8th/fragment/AlbumFragment.kt
@@ -29,7 +29,6 @@ class AlbumFragment : Fragment() {
         // 🔹 HomeFragment에서 전달받은 데이터 가져오기
         val albumTitle = arguments?.getString("title") ?: "제목 없음"
         val artist = arguments?.getString("artist") ?: "아티스트 정보 없음"
-        //val imageRes = arguments?.getInt("imageRes", R.drawable.ic_launcher_foreground)
         val imageRes = arguments?.getInt("imageRes") ?: R.drawable.ic_launcher_foreground
 
         // 🔹 UI 업데이트 (binding 사용)

--- a/app/src/main/java/com/example/umc_8th/fragment/AlbumRecyclerFragment.kt
+++ b/app/src/main/java/com/example/umc_8th/fragment/AlbumRecyclerFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.example.umc_8th.adapter.AlbumAdapter
@@ -11,6 +12,7 @@ import com.example.umc_8th.AlbumItem
 import com.example.umc_8th.R
 import com.example.umc_8th.databinding.FragmentAlbumRecyclerBinding
 import androidx.navigation.fragment.findNavController
+import com.example.umc_8th.MainActivity_2nd
 
 class AlbumRecyclerFragment : Fragment() {
 
@@ -40,14 +42,20 @@ class AlbumRecyclerFragment : Fragment() {
         )
 
         // 어댑터 설정 + 클릭 이벤트 추가 ✅
-        albumAdapter = AlbumAdapter(albumList) { album ->
-            val bundle = Bundle().apply {
-                putString("title", album.albumName)
-                putString("artist", album.artistName)
-                putInt("imageRes", album.albumImage)
+        albumAdapter = AlbumAdapter(
+            albumList,
+            onPlayClick = { title, artist ->
+                (requireActivity() as MainActivity_2nd).updateMiniPlayer(title, artist, isPlaying = true)
+            },
+            onItemClick = { album ->
+                val bundle = Bundle().apply {
+                    putString("title", album.albumName)
+                    putString("artist", album.artistName)
+                    putInt("imageRes", album.albumImage)
+                }
+                findNavController().navigate(R.id.action_homeFragment_to_albumFragment, bundle)
             }
-            findNavController().navigate(R.id.action_homeFragment_to_albumFragment, bundle)
-        }
+        )
 
         // RecyclerView 설정 ✅
         //binding.albumRecyclerView.layoutManager = LinearLayoutManager(requireContext())

--- a/app/src/main/java/com/example/umc_8th/fragment/AlbumRecyclerFragment.kt
+++ b/app/src/main/java/com/example/umc_8th/fragment/AlbumRecyclerFragment.kt
@@ -32,7 +32,7 @@ class AlbumRecyclerFragment : Fragment() {
 
         // 📌 더미 데이터 추가 (여기에 position 값에 따라 다르게 넣을 수도 있음)
         val albumList = listOf(
-            AlbumItem(R.drawable.img_album_exp, "Butter", "방탄소년단(BTS)"),
+            AlbumItem(R.drawable.img_album_exp6, "Weekend", "태연"),
             AlbumItem(R.drawable.img_album_exp2, "LILAC", "아이유(IU)"),
             AlbumItem(R.drawable.img_album_exp3, "Album Three", "Artist C"),
             AlbumItem(R.drawable.img_album_exp4, "Album Four", "Artist D"),

--- a/app/src/main/java/com/example/umc_8th/fragment/AlbumRecyclerFragment.kt
+++ b/app/src/main/java/com/example/umc_8th/fragment/AlbumRecyclerFragment.kt
@@ -6,7 +6,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.example.umc_8th.AlbumAdapter
+import com.example.umc_8th.adapter.AlbumAdapter
 import com.example.umc_8th.AlbumItem
 import com.example.umc_8th.R
 import com.example.umc_8th.databinding.FragmentAlbumRecyclerBinding

--- a/app/src/main/java/com/example/umc_8th/fragment/BannerAlbumFragment.kt
+++ b/app/src/main/java/com/example/umc_8th/fragment/BannerAlbumFragment.kt
@@ -4,15 +4,12 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Toast
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
-import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import com.example.umc_8th.BannerAlbumAdapter
+import com.example.umc_8th.adapter.BannerAlbumAdapter
 import com.example.umc_8th.BannerAlbumItem
-import com.example.umc_8th.BannerItem
 import com.example.umc_8th.MainActivity_2nd
 import com.example.umc_8th.R
 import com.example.umc_8th.databinding.FragmentBannerAlbumBinding

--- a/app/src/main/java/com/example/umc_8th/fragment/HomeFragment.kt
+++ b/app/src/main/java/com/example/umc_8th/fragment/HomeFragment.kt
@@ -5,14 +5,13 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import androidx.recyclerview.widget.LinearLayoutManager
-import com.example.umc_8th.AlbumAdapter
+import com.example.umc_8th.adapter.AlbumAdapter
 import com.example.umc_8th.AlbumItem
 import com.example.umc_8th.R
 import androidx.navigation.fragment.findNavController
-import com.example.umc_8th.BannerAdapter
+import com.example.umc_8th.adapter.BannerAdapter
 import com.example.umc_8th.BannerItem
-import com.example.umc_8th.StateAdapter
+import com.example.umc_8th.adapter.StateAdapter
 import com.example.umc_8th.databinding.FragmentHomeBinding
 import com.google.android.material.tabs.TabLayoutMediator
 

--- a/app/src/main/java/com/example/umc_8th/fragment/HomeFragment.kt
+++ b/app/src/main/java/com/example/umc_8th/fragment/HomeFragment.kt
@@ -11,6 +11,7 @@ import com.example.umc_8th.R
 import androidx.navigation.fragment.findNavController
 import com.example.umc_8th.adapter.BannerAdapter
 import com.example.umc_8th.BannerItem
+import com.example.umc_8th.MainActivity_2nd
 import com.example.umc_8th.adapter.StateAdapter
 import com.example.umc_8th.databinding.FragmentHomeBinding
 import com.google.android.material.tabs.TabLayoutMediator
@@ -42,15 +43,18 @@ class HomeFragment : Fragment() {
         )
 
         // 어댑터 설정
-        albumAdapter = AlbumAdapter(albumList) { album ->
+        albumAdapter = AlbumAdapter(albumList, { title, artist ->
+            // 플레이 버튼 클릭 시 미니플레이어에 데이터 전달
+            (requireActivity() as MainActivity_2nd).updateMiniPlayer(title, artist, isPlaying = true)
+        }, { album ->
+            // 앨범 클릭 시 상세 화면으로 이동
             val bundle = Bundle().apply {
                 putString("title", album.albumName)
                 putString("artist", album.artistName)
                 putInt("imageRes", album.albumImage)
             }
-
-            findNavController().navigate(R.id.action_homeFragment_to_albumFragment, bundle) // 🔥 navigate 사용
-        }
+            findNavController().navigate(R.id.action_homeFragment_to_albumFragment, bundle)
+        })
         //binding.albumRecyclerView.adapter = albumAdapter
 
         val bannerList = listOf(

--- a/app/src/main/java/com/example/umc_8th/fragment/ProfileFragment.kt
+++ b/app/src/main/java/com/example/umc_8th/fragment/ProfileFragment.kt
@@ -5,7 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import com.example.umc_8th.StorageAdapter
+import com.example.umc_8th.adapter.StorageAdapter
 import com.example.umc_8th.databinding.FragmentProfileBinding
 import com.google.android.material.tabs.TabLayoutMediator
 

--- a/app/src/main/java/com/example/umc_8th/fragment/SavedFragment.kt
+++ b/app/src/main/java/com/example/umc_8th/fragment/SavedFragment.kt
@@ -5,15 +5,21 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.example.umc_8th.R
 import com.example.umc_8th.SavedData
 import com.example.umc_8th.adapter.SavedAdapter
 import com.example.umc_8th.databinding.FragmentSavedBinding
+import com.example.umc_8th.viewmodel.SavedViewModel
 
 class SavedFragment:Fragment(){
     private var _binding: FragmentSavedBinding? = null
     private val binding get() = _binding!!
+
+    //뷰모델 추가
+    private val savedViewModel: SavedViewModel by viewModels()
+    private lateinit var savedAdapter: SavedAdapter
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         _binding = FragmentSavedBinding.inflate(inflater, container, false)
@@ -22,70 +28,20 @@ class SavedFragment:Fragment(){
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        //음악 리스트
-        val savedList = mutableListOf(
-            SavedData(
-                savedImg = R.drawable.img_album_lovewinsall,
-                savedName = "love wins all",
-                savedArtist = "아이유"
-            ),
-            SavedData(
-                savedImg = R.drawable.img_album_supernova,
-                savedName = "supernova",
-                savedArtist = "aespa"
-            ),
-            SavedData(
-                savedImg = R.drawable.img_album_drama,
-                savedName = "drama",
-                savedArtist = "aespa"
-            ),
-            SavedData(
-                savedImg = R.drawable.img_album_exp3,
-                savedName = "next level",
-                savedArtist = "aespa"
-            ),
-            SavedData(
-                savedImg = R.drawable.img_album_exp6,
-                savedName = "weekend",
-                savedArtist = "태연"
-            ),
-            SavedData(
-                savedImg = R.drawable.img_album_lovewinsall,
-                savedName = "love wins all",
-                savedArtist = "아이유"
-            ),
-            SavedData(
-                savedImg = R.drawable.img_album_supernova,
-                savedName = "supernova",
-                savedArtist = "aespa"
-            ),
-            SavedData(
-                savedImg = R.drawable.img_album_drama,
-                savedName = "drama",
-                savedArtist = "aespa"
-            ),
-            SavedData(
-                savedImg = R.drawable.img_album_exp3,
-                savedName = "next level",
-                savedArtist = "aespa"
-            ),
-            SavedData(
-                savedImg = R.drawable.img_album_exp6,
-                savedName = "weekend",
-                savedArtist = "태연"
-            )
-        )
 
-        lateinit var savedAdapter: SavedAdapter //먼저 선언
 
-        savedAdapter = SavedAdapter(savedList, object : SavedAdapter.OnItemClickListener {
-            override fun onItemClick(position: Int){
-                savedAdapter.removeItem(position)
+        savedAdapter = SavedAdapter(mutableListOf(), object : SavedAdapter.OnItemClickListener {
+            override fun onItemClick(position: Int) {
+                savedViewModel.removeItem(position)  // 아이템 클릭 시 아이템 제거
             }
         })
-        
+
         binding.savedRecyclerView.layoutManager =LinearLayoutManager(requireContext(),LinearLayoutManager.VERTICAL, false)
         binding.savedRecyclerView.adapter = savedAdapter
+
+        savedViewModel.savedList.observe(viewLifecycleOwner) { list ->
+            savedAdapter.updateList(list)  // 데이터 변경 시 어댑터에 업데이트
+        }
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/example/umc_8th/fragment/SavedFragment.kt
+++ b/app/src/main/java/com/example/umc_8th/fragment/SavedFragment.kt
@@ -23,7 +23,7 @@ class SavedFragment:Fragment(){
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         //음악 리스트
-        val savedList = listOf(
+        val savedList = mutableListOf(
             SavedData(
                 savedImg = R.drawable.img_album_lovewinsall,
                 savedName = "love wins all",
@@ -76,7 +76,14 @@ class SavedFragment:Fragment(){
             )
         )
 
-        val savedAdapter = SavedAdapter(savedList)
+        lateinit var savedAdapter: SavedAdapter //먼저 선언
+
+        savedAdapter = SavedAdapter(savedList, object : SavedAdapter.OnItemClickListener {
+            override fun onItemClick(position: Int){
+                savedAdapter.removeItem(position)
+            }
+        })
+        
         binding.savedRecyclerView.layoutManager =LinearLayoutManager(requireContext(),LinearLayoutManager.VERTICAL, false)
         binding.savedRecyclerView.adapter = savedAdapter
     }

--- a/app/src/main/java/com/example/umc_8th/fragment/SavedFragment.kt
+++ b/app/src/main/java/com/example/umc_8th/fragment/SavedFragment.kt
@@ -5,19 +5,84 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.example.umc_8th.R
+import com.example.umc_8th.SavedData
+import com.example.umc_8th.adapter.SavedAdapter
 import com.example.umc_8th.databinding.FragmentSavedBinding
 
 class SavedFragment:Fragment(){
-    private var mBinding: FragmentSavedBinding? = null
+    private var _binding: FragmentSavedBinding? = null
+    private val binding get() = _binding!!
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        val binding = FragmentSavedBinding.inflate(inflater,container,false)
-        mBinding = binding
-        return mBinding?.root
+        _binding = FragmentSavedBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        //음악 리스트
+        val savedList = listOf(
+            SavedData(
+                savedImg = R.drawable.img_album_lovewinsall,
+                savedName = "love wins all",
+                savedArtist = "아이유"
+            ),
+            SavedData(
+                savedImg = R.drawable.img_album_supernova,
+                savedName = "supernova",
+                savedArtist = "aespa"
+            ),
+            SavedData(
+                savedImg = R.drawable.img_album_drama,
+                savedName = "drama",
+                savedArtist = "aespa"
+            ),
+            SavedData(
+                savedImg = R.drawable.img_album_exp3,
+                savedName = "next level",
+                savedArtist = "aespa"
+            ),
+            SavedData(
+                savedImg = R.drawable.img_album_exp6,
+                savedName = "weekend",
+                savedArtist = "태연"
+            ),
+            SavedData(
+                savedImg = R.drawable.img_album_lovewinsall,
+                savedName = "love wins all",
+                savedArtist = "아이유"
+            ),
+            SavedData(
+                savedImg = R.drawable.img_album_supernova,
+                savedName = "supernova",
+                savedArtist = "aespa"
+            ),
+            SavedData(
+                savedImg = R.drawable.img_album_drama,
+                savedName = "drama",
+                savedArtist = "aespa"
+            ),
+            SavedData(
+                savedImg = R.drawable.img_album_exp3,
+                savedName = "next level",
+                savedArtist = "aespa"
+            ),
+            SavedData(
+                savedImg = R.drawable.img_album_exp6,
+                savedName = "weekend",
+                savedArtist = "태연"
+            )
+        )
+
+        val savedAdapter = SavedAdapter(savedList)
+        binding.savedRecyclerView.layoutManager =LinearLayoutManager(requireContext(),LinearLayoutManager.VERTICAL, false)
+        binding.savedRecyclerView.adapter = savedAdapter
     }
 
     override fun onDestroyView() {
-        mBinding = null
+        _binding = null
         super.onDestroyView()
     }
 }

--- a/app/src/main/java/com/example/umc_8th/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/example/umc_8th/viewmodel/MainViewModel.kt
@@ -1,4 +1,4 @@
-package com.example.umc_8th
+package com.example.umc_8th.viewmodel
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData

--- a/app/src/main/java/com/example/umc_8th/viewmodel/SavedViewModel.kt
+++ b/app/src/main/java/com/example/umc_8th/viewmodel/SavedViewModel.kt
@@ -1,0 +1,84 @@
+// com.example.umc_8th.viewmodel.SavedViewModel.kt
+
+package com.example.umc_8th.viewmodel
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import com.example.umc_8th.R
+import com.example.umc_8th.SavedData
+
+class SavedViewModel : ViewModel() {
+
+    private val _savedList = MutableLiveData<MutableList<SavedData>>().apply {
+        value = mutableListOf(
+            SavedData(
+                savedImg = R.drawable.img_album_lovewinsall,
+                savedName = "love wins all",
+                savedArtist = "아이유"
+            ),
+            SavedData(
+                savedImg = R.drawable.img_album_supernova,
+                savedName = "supernova",
+                savedArtist = "aespa"
+            ),
+            SavedData(
+                savedImg = R.drawable.img_album_drama,
+                savedName = "drama",
+                savedArtist = "aespa"
+            ),
+            SavedData(
+                savedImg = R.drawable.img_album_exp3,
+                savedName = "next level",
+                savedArtist = "aespa"
+            ),
+            SavedData(
+                savedImg = R.drawable.img_album_exp6,
+                savedName = "weekend",
+                savedArtist = "태연"
+            ),
+            SavedData(
+                savedImg = R.drawable.img_album_lovewinsall,
+                savedName = "love wins all",
+                savedArtist = "아이유"
+            ),
+            SavedData(
+                savedImg = R.drawable.img_album_supernova,
+                savedName = "supernova",
+                savedArtist = "aespa"
+            ),
+            SavedData(
+                savedImg = R.drawable.img_album_drama,
+                savedName = "drama",
+                savedArtist = "aespa"
+            ),
+            SavedData(
+                savedImg = R.drawable.img_album_exp3,
+                savedName = "next level",
+                savedArtist = "aespa"
+            ),
+            SavedData(
+                savedImg = R.drawable.img_album_exp6,
+                savedName = "weekend",
+                savedArtist = "태연"
+            )
+        )
+    }
+
+    val savedList: LiveData<MutableList<SavedData>> = _savedList
+
+//    fun removeItem(position: Int) {
+//        _savedList.value?.let {
+//            if (position in it.indices) {
+//                it.removeAt(position)
+//                _savedList.value = it.toMutableList() // 트리거를 위해 새 리스트로 할당
+//            }
+//        }
+//    }
+    fun removeItem(position: Int) {
+        val updatedList = _savedList.value?.toMutableList()
+        updatedList?.removeAt(position)
+        _savedList.value = updatedList
+    }
+
+}

--- a/app/src/main/res/layout/activity_main_2nd.xml
+++ b/app/src/main/res/layout/activity_main_2nd.xml
@@ -38,7 +38,7 @@
     <LinearLayout
         android:id="@+id/miniPlayer"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="60dp"
         android:background="@color/light_gray"
         android:orientation="horizontal">
         <LinearLayout

--- a/app/src/main/res/layout/album_recyclerview.xml
+++ b/app/src/main/res/layout/album_recyclerview.xml
@@ -6,39 +6,57 @@
     android:layout_height="260dp"
     app:cardElevation="0dp">
 
-    <LinearLayout
+    <FrameLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical"
-        >
+        android:layout_height="match_parent">
 
-        <ImageView
-            android:id="@+id/album_img"
-            android:layout_width="169dp"
-            android:layout_height="155dp"
-            android:layout_gravity="center"
-            android:layout_marginTop="20dp"
-            android:src="@mipmap/ic_launcher" />
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:orientation="vertical">
 
-        <TextView
-            android:id="@+id/album_name"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:layout_marginTop="5dp"
-            android:text="앨범명"
-            android:textSize="20dp" />
+            <FrameLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
 
-        <TextView
-            android:id="@+id/artist_name"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="가수명"
-            android:textSize="15dp"
-            android:layout_gravity="center"
-            android:layout_marginTop="5dp"/>
+                <ImageView
+                    android:id="@+id/album_img"
+                    android:layout_width="150dp"
+                    android:layout_height="150dp"
+                    android:layout_gravity="center_horizontal"
+                    android:layout_marginTop="20dp"
+                    android:layout_marginStart="15dp"
+                    android:layout_marginEnd="15dp"
+                    android:src="@mipmap/ic_launcher" />
 
-    </LinearLayout>
+                <ImageView
+                    android:id="@+id/overlay_icon"
+                    android:layout_width="60dp"
+                    android:layout_height="60dp"
+                    android:layout_marginEnd="20dp"
+                    android:layout_gravity="bottom|end"
+                    android:src="@drawable/widget_black_play"
+                    android:background="@android:color/transparent" />
+            </FrameLayout>
 
+            <TextView
+                android:id="@+id/album_name"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp"
+                android:layout_marginStart="15dp"
+                android:text="앨범명"
+                android:textSize="20dp" />
 
+            <TextView
+                android:id="@+id/artist_name"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="가수명"
+                android:layout_marginStart="15dp"
+                android:textSize="15dp"
+                android:layout_marginTop="5dp" />
+        </LinearLayout>
+
+    </FrameLayout>
 </androidx.cardview.widget.CardView>

--- a/app/src/main/res/layout/album_recyclerview.xml
+++ b/app/src/main/res/layout/album_recyclerview.xml
@@ -30,7 +30,7 @@
                     android:src="@mipmap/ic_launcher" />
 
                 <ImageView
-                    android:id="@+id/overlay_icon"
+                    android:id="@+id/play_btn"
                     android:layout_width="60dp"
                     android:layout_height="60dp"
                     android:layout_marginEnd="20dp"

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -16,13 +16,13 @@
         android:orientation="vertical"
         android:fillViewport="true">
 
+
         <androidx.viewpager2.widget.ViewPager2
             android:id="@+id/banner_pager"
             android:layout_width="match_parent"
             android:layout_height="380dp"
             tools:layout_editor_absoluteX="-54dp"
-            tools:layout_editor_absoluteY="-194dp"/>
-
+            tools:layout_editor_absoluteY="-194dp" />
 
         <com.tbuonomo.viewpagerdotsindicator.DotsIndicator
             android:id="@+id/dotsIndicator"

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -6,6 +6,7 @@
     android:layout_height="match_parent"
     android:id="@+id/profileFragment"
     android:orientation="vertical"
+    android:background="@color/white"
     tools:context="com.example.umc_8th.fragment.ProfileFragment"
     >
 
@@ -41,6 +42,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="20dp"
+        android:background="@color/white"
         app:layout_constraintTop_toBottomOf="@id/storage"
         app:tabSelectedTextColor="@android:color/black"
         app:tabTextColor="@android:color/black">

--- a/app/src/main/res/layout/fragment_saved.xml
+++ b/app/src/main/res/layout/fragment_saved.xml
@@ -2,16 +2,66 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-             android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:background="@color/white">
 
-    <TextView
-        android:id="@+id/textView4"
-        android:layout_width="wrap_content"
+    <LinearLayout
+        android:id="@+id/topLinear"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="저장한 곡이 없습니다"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
+        android:orientation="horizontal"
+        android:layout_marginTop="10dp"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent">
+
+        <ImageView
+            android:layout_width="30dp"
+            android:layout_height="30dp"
+            android:layout_marginStart="15dp"
+            android:src="@drawable/btn_playlist_select_off"
+            android:layout_gravity="center_vertical"/>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="전체선택"
+            android:layout_gravity="center_vertical"/>
+
+        <ImageView
+            android:layout_width="30dp"
+            android:layout_height="30dp"
+            android:layout_marginStart="20dp"
+            android:src="@drawable/ic_browse_arrow_right"
+            android:layout_gravity="center_vertical"/>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="전체듣기"
+            android:layout_gravity="center_vertical"/>
+
+        <View
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_weight="1" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="편집"
+            android:layout_gravity="center_vertical"
+            android:layout_marginEnd="15dp"/>
+
+    </LinearLayout>
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/savedRecyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toBottomOf="@+id/topLinear"
+        android:layout_marginTop="10dp"
+        android:clipToPadding="false"
+        android:paddingBottom="55dp"/>
+
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_saved.xml
+++ b/app/src/main/res/layout/item_saved.xml
@@ -52,12 +52,14 @@
             android:layout_weight="1"/>
 
         <ImageView
+            android:id="@+id/playBtn"
             android:layout_width="40dp"
             android:layout_height="40dp"
             android:src="@drawable/btn_miniplayer_play"
             android:layout_gravity="center_vertical"/>
 
         <ImageView
+            android:id="@+id/moreBtn"
             android:layout_width="40dp"
             android:layout_height="40dp"
             android:src="@drawable/btn_player_more"

--- a/app/src/main/res/layout/item_saved.xml
+++ b/app/src/main/res/layout/item_saved.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    app:cardElevation="0dp"
+    app:cardBackgroundColor="@android:color/transparent"
+    app:cardUseCompatPadding="false"
+    app:cardPreventCornerOverlap="false">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:layout_marginTop="10dp"
+        android:layout_marginBottom="10dp">
+
+        <ImageView
+            android:id="@+id/saved_img"
+            android:layout_width="60dp"
+            android:layout_height="60dp"
+            android:layout_marginStart="15dp"
+            android:src="@drawable/img_album_lovewinsall"/>
+
+        <LinearLayout
+            android:layout_marginStart="10dp"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:layout_gravity="center_vertical">
+
+            <TextView
+                android:id="@+id/saved_name"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="love wins all"
+                android:textSize="20dp"/>
+
+            <TextView
+                android:id="@+id/saved_artist"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="아이유"
+                android:textSize="15dp"/>
+
+
+        </LinearLayout>
+
+        <View
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_weight="1"/>
+
+        <ImageView
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:src="@drawable/btn_miniplayer_play"
+            android:layout_gravity="center_vertical"/>
+
+        <ImageView
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:src="@drawable/btn_player_more"
+            android:layout_gravity="center_vertical"
+            android:layout_marginEnd="15dp"/>
+
+        
+    </LinearLayout>
+
+</androidx.cardview.widget.CardView>
+


### PR DESCRIPTION
# 📌 PR 제목
> RecyclerView & Adapter 

## ✅ 변경 사항
> 이번 PR에서 변경된 내용을 간략히 정리해주세요.
- [1] item_album 구현
: RecyclerView의 아이템의 기본 형태를 구성
: 앨범 이미지 위에 play버튼을 겹쳐놓기 위해 FrameLayout 사용 
- [2] 보관함 RecyclerView
: item, Adapter를 만들고 recyclerview를 띄우는 Fragment에 연결(리스트 데이터 초기화 및 어댑터 연결 등...)
- [3] RecyclerView 클릭, 삭제
: 뷰바인딩으로 more버튼에 클릭리스너를 달고, 어댑터에서 remove할 수 있도록 설정
: 화면 전환 후 돌아왔을때 remove한 상태가 남아있도록 하기 위해 UI와 구별되는 뷰모델 이용
-[4] 오늘 발매 음악 -> miniplayer 데이터전달


## 📷 영상 및 스크린샷
> 
[6th.webm](https://github.com/user-attachments/assets/fca71231-5782-46a8-b5bf-057dea35d428)


## 🔗 알게 된 사항
> dataclass와 뷰모델을 언제 사용해야 하는지 제대로 알게 된 것 같다
dataclass -> 뭔가 정적이고 바꿀필요 없는 형태
뷰모델 -> 아이템이 동적이고, 데이터의 변화를 기억해야할 때

## 📝 질문 사항
> 앱을 재실행해도 데이터가 보존되는 경우는 어떻게 구현해야 하는가?
> 리사이클러뷰를 구성하는 다양한 방법 중 요새 트렌드?

Closes #37 