### PR TITLE
[어헛차/#51] 9주차 구현

### DIFF
--- a/app/floclone/src/main/AndroidManifest.xml
+++ b/app/floclone/src/main/AndroidManifest.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"

--- a/app/floclone/src/main/java/com/example/floclone/LoginActivity.kt
+++ b/app/floclone/src/main/java/com/example/floclone/LoginActivity.kt
@@ -11,6 +11,10 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.widget.doAfterTextChanged
+import com.example.floclone.api.AuthService
+import com.example.floclone.api.AuthView
+import com.example.floclone.api.LoginResult
+import com.example.floclone.api.SignUpResult
 import com.google.android.material.button.MaterialButton
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseAuthInvalidCredentialsException
@@ -18,7 +22,7 @@ import com.google.firebase.auth.FirebaseAuthInvalidUserException
 import com.google.firebase.database.DatabaseReference
 import com.google.firebase.database.FirebaseDatabase
 
-class LoginActivity : AppCompatActivity() {
+class LoginActivity : AppCompatActivity(), AuthView {
 
     private lateinit var etId : EditText
     private lateinit var etEmail : EditText
@@ -27,6 +31,9 @@ class LoginActivity : AppCompatActivity() {
     private lateinit var btnlogin : MaterialButton
     private lateinit var btnSingin : TextView
     private lateinit var tvError : TextView
+
+    //api 추가
+    private lateinit var authService: AuthService
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -40,9 +47,11 @@ class LoginActivity : AppCompatActivity() {
         btnlogin = findViewById<MaterialButton>(R.id.btn_login_loginActivity)
         tvError = findViewById<TextView>(R.id.tv_errorlogin_loginActivity)
 
+        authService = AuthService(this)
 
         btnlogin.setOnClickListener {
-            validLogin()
+            //validLogin()
+            validLoginWithApi()
         }
 
         btnSingin.setOnClickListener {
@@ -55,6 +64,22 @@ class LoginActivity : AppCompatActivity() {
             v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
             insets
         }
+    }
+
+    private fun validLoginWithApi(){
+        var id = etId.text.toString().trim()
+        var email = etEmail.text.toString().trim()
+        var pw = etPw.text.toString().trim()
+
+        var userId = "$id@$email"
+
+        if (id.isEmpty() || email.isEmpty() || pw.isEmpty()) {
+            tvError.text = "잘못된 입력입니다."
+            tvError.visibility = TextView.VISIBLE
+            return
+        }
+        //여기서는 api 호출만 하고 성공 실패는 밑의 override에
+        authService.login(userId, pw)
     }
 
     private fun validLogin(){
@@ -117,5 +142,39 @@ class LoginActivity : AppCompatActivity() {
             }
     }
 
+    override fun onSignUpSuccess(result: SignUpResult) {
+
+    }
+
+    override fun onSignUpFailure(errorMsg: String) {
+
+    }
+
+    override fun onLoginSuccess(result: LoginResult) {
+        runOnUiThread {
+            //1. 에러 메시지 없애기
+            tvError.visibility = TextView.INVISIBLE
+
+            //2. auth로부터 uid 받고, 이를 sharedPreference에 저장
+            val uid = result.memberId
+            val sharedPref = getSharedPreferences("login", MODE_PRIVATE)
+
+            sharedPref.edit()
+                .putBoolean("loginCheck", true)
+                .putString("id", uid.toString())
+                .apply()
+
+            //3. 로그인 성공
+            Toast.makeText(this, "로그인 성공!", Toast.LENGTH_SHORT).show()
+            finish()
+        }
+
+    }
+
+    override fun onLoginFailure(errorMsg: String) {
+        runOnUiThread {
+            Toast.makeText(this, "errorMsg", Toast.LENGTH_SHORT).show()
+        }
+    }
 
 }

--- a/app/floclone/src/main/java/com/example/floclone/SignUpActivity.kt
+++ b/app/floclone/src/main/java/com/example/floclone/SignUpActivity.kt
@@ -74,7 +74,7 @@ class SignUpActivity : AppCompatActivity(), AuthView {
         var email = etEmail.text.toString().trim()
         var pw = etPw.text.toString().trim()
         var userId = "$id@$email"
-        authService.singUp("uhutcha",userId,pw)
+        authService.signUp("uhutcha",userId,pw)
     }
 
     private fun validInputcheck(){

--- a/app/floclone/src/main/java/com/example/floclone/SignUpActivity.kt
+++ b/app/floclone/src/main/java/com/example/floclone/SignUpActivity.kt
@@ -14,10 +14,14 @@ import com.google.android.material.button.MaterialButton
 import com.google.firebase.database.FirebaseDatabase
 import android.graphics.Color
 import android.widget.Toast
+import com.example.floclone.api.AuthService
+import com.example.floclone.api.AuthView
+import com.example.floclone.api.LoginResult
+import com.example.floclone.api.SignUpResult
 import com.google.firebase.auth.FirebaseAuth
 
 
-class SignUpActivity : AppCompatActivity() {
+class SignUpActivity : AppCompatActivity(), AuthView {
 
     private lateinit var etId : EditText
     private lateinit var etEmail : EditText
@@ -25,6 +29,9 @@ class SignUpActivity : AppCompatActivity() {
     private lateinit var etPwcheck : EditText
     private lateinit var btnSignin : MaterialButton
     private lateinit var tvError : TextView
+
+    //api 추가
+    private lateinit var authService: AuthService
 
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -39,6 +46,7 @@ class SignUpActivity : AppCompatActivity() {
         btnSignin = findViewById<MaterialButton>(R.id.btn_signin_signActivity)
         tvError = findViewById<TextView>(R.id.tv_errorsign_signActivity)
 
+        authService = AuthService(this)
 
         // 모든 editText에 대해 돌면서 체크
         listOf(etId, etEmail, etPw, etPwcheck).forEach { editText ->
@@ -48,7 +56,10 @@ class SignUpActivity : AppCompatActivity() {
         }
 
         btnSignin.setOnClickListener {
-            signUserInfo()
+            //signUserInfo()
+
+            //외부 API를 이용해 핸들
+            signUserInfoWithApi()
         }
 
         ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.main)) { v, insets ->
@@ -56,6 +67,14 @@ class SignUpActivity : AppCompatActivity() {
             v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
             insets
         }
+    }
+
+    private fun signUserInfoWithApi(){
+        var id = etId.text.toString().trim()
+        var email = etEmail.text.toString().trim()
+        var pw = etPw.text.toString().trim()
+        var userId = "$id@$email"
+        authService.singUp("uhutcha",userId,pw)
     }
 
     private fun validInputcheck(){
@@ -133,4 +152,45 @@ class SignUpActivity : AppCompatActivity() {
             }
 
     }
+
+    override fun onSignUpSuccess(result: SignUpResult) {
+
+        runOnUiThread {
+
+            var id = etId.text.toString().trim()
+            var email = etEmail.text.toString().trim()
+            var userId = "$id@$email"
+
+            var uid = result.memberId.toString()
+
+            val dbUser = FirebaseDatabase.getInstance().getReference("User")
+            val userData = mapOf(
+                "uid" to uid,
+                "email" to userId
+            )
+            dbUser.child(uid).setValue(userData)
+
+            Toast.makeText(
+                this,
+                "회원가입 성공! ID=${result.memberId}",
+                //현재 ID = 14
+                Toast.LENGTH_SHORT
+            ).show()
+            finish()
+        }
+    }
+
+    override fun onSignUpFailure(errorMsg: String) {
+
+        Toast.makeText(this, "${errorMsg}", Toast.LENGTH_SHORT).show()
+    }
+
+    override fun onLoginSuccess(result: LoginResult) {
+
+    }
+
+    override fun onLoginFailure(errorMsg: String) {
+
+    }
+
 }

--- a/app/floclone/src/main/java/com/example/floclone/api/ApiService.kt
+++ b/app/floclone/src/main/java/com/example/floclone/api/ApiService.kt
@@ -6,6 +6,7 @@ import retrofit2.http.GET
 import retrofit2.http.POST
 
 //각 API 서비스를 제공하는 객체
+
 interface ApiService {
     //notation으로 정의된 거 작성(회원가입은 POST)
 

--- a/app/floclone/src/main/java/com/example/floclone/api/ApiService.kt
+++ b/app/floclone/src/main/java/com/example/floclone/api/ApiService.kt
@@ -1,0 +1,18 @@
+package com.example.floclone.api
+
+import retrofit2.Call
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.POST
+
+//각 API 서비스를 제공하는 객체
+interface ApiService {
+    //notation으로 정의된 거 작성(회원가입은 POST)
+
+    @POST("join")
+    fun signUP(@Body req: SignUpRequest): Call<SignUpResponse>
+
+    @POST("login")
+    fun login(@Body req: LoginRequest): Call<LoginResponse>
+
+}

--- a/app/floclone/src/main/java/com/example/floclone/api/AuthService.kt
+++ b/app/floclone/src/main/java/com/example/floclone/api/AuthService.kt
@@ -1,0 +1,94 @@
+package com.example.floclone.api
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
+
+//각 기능을 구현해 클래스화
+class AuthService(private val view: AuthView) {
+    //NetworkManager에 정의한 인스턴스 + ApiService에 정의한 서비스 연결
+    private val api = NetworkManager.retrofit.create(ApiService::class.java)
+
+    //회원가입 기능
+    fun singUp(name: String, email: String, pw: String){
+        //결국에는 NetworkManger -> Retrofit 인스턴스 + ApiService 연결 후 호출
+        //꼭 enqueue로 비동기로 넣자
+        api.signUP(SignUpRequest(name, email, pw))
+            .enqueue(object : Callback<SignUpResponse>{
+                override fun onResponse(
+                    call: Call<SignUpResponse?>,
+                    response: Response<SignUpResponse?>
+                ) {
+
+                    /**  이를 response가 받아서 이를 해체해서 확인하기
+                     * data class Response<T> (
+                     *     val isSuccesss: Boolean,
+                     *     val code: String,
+                     *     val message: String,
+                     *     val result: T?
+                     * )
+                     * **/
+
+                    //response가 성공적으로 받아졌어
+                    if(response.isSuccessful){
+                        //받은 내용을 뜯어서
+                        val body = response.body()
+                        //유효하면
+                        if (body != null && body.isSuccess && body.result != null) {
+                            // 성공: SignUpResult 객체 전달 - 콜백함수로
+                            view.onSignUpSuccess(body.result)
+                        } else {
+                            // API 레벨 실패(400 등) 또는 isSuccesss == false
+                            val msg = body?.message ?: "회원가입 실패: HTTP ${response.code()}"
+                            view.onSignUpFailure(msg)
+                        }
+                    } else {
+                        // HTTP 에러
+                        view.onSignUpFailure("회원가입 실패: HTTP ${response.code()}")
+                    }
+
+                }
+
+                override fun onFailure(call: Call<SignUpResponse?>, t: Throwable) {
+                    view.onSignUpFailure("네트워크 오류: ${t.message}")
+                }
+            })
+    }
+
+    fun login(email: String, pw: String){
+        api.login(LoginRequest(email, pw))
+            .enqueue(object : Callback<LoginResponse>{
+                override fun onResponse(
+                    call: Call<LoginResponse?>,
+                    response: Response<LoginResponse?>
+                ) {
+                    //제대로 받았어
+                    if(response.isSuccessful){
+                        val body = response.body()
+                        if (body != null && body.isSuccess && body.result != null) {
+                            // 성공: LoginResult 객체 전달
+                            view.onLoginSuccess(body.result)
+                        }
+                        else{
+                            // API 레벨 실패(401 등) 또는 isSuccesss == false
+                            val msg = body?.message ?: "로그인 실패: HTTP ${response.code()}"
+                            view.onLoginFailure(msg)
+                        }
+                    }
+                    //문제가 생겼어
+                    else{
+                        val msg = when (response.code()) {
+                            401 -> "인증 실패: 계정 정보를 확인해주세요."
+                            else -> "로그인 실패: HTTP ${response.code()}"
+                        }
+                        view.onLoginFailure(msg)
+                    }
+                }
+
+
+                override fun onFailure(call: Call<LoginResponse?>, t: Throwable) {
+                    view.onLoginFailure("네트워크 오류: ${t.message}")
+                }
+            })
+    }
+
+}

--- a/app/floclone/src/main/java/com/example/floclone/api/AuthService.kt
+++ b/app/floclone/src/main/java/com/example/floclone/api/AuthService.kt
@@ -9,9 +9,9 @@ class AuthService(private val view: AuthView) {
     private val api = NetworkManager.retrofit.create(ApiService::class.java)
 
     //회원가입 기능
-    fun singUp(name: String, email: String, pw: String){
+    fun signUp(name: String, email: String, pw: String){
         //결국에는 NetworkManger -> Retrofit 인스턴스 + ApiService 연결 후 호출
-        //꼭 enqueue로 비동기로 넣자
+        //꼭 enqueue로 비동기로 넣자 (apiService에 정의된 signUP 실행)
         api.signUP(SignUpRequest(name, email, pw))
             .enqueue(object : Callback<SignUpResponse>{
                 override fun onResponse(
@@ -34,7 +34,8 @@ class AuthService(private val view: AuthView) {
                         val body = response.body()
                         //유효하면
                         if (body != null && body.isSuccess && body.result != null) {
-                            // 성공: SignUpResult 객체 전달 - 콜백함수로
+                            // 성공: SignUpResult 객체 전달 - 콜백함수로(
+                            // LoginActivity/SignUPactivity에서 이 콜백함수로 받은 내용을 통해 내용 정의
                             view.onSignUpSuccess(body.result)
                         } else {
                             // API 레벨 실패(400 등) 또는 isSuccesss == false

--- a/app/floclone/src/main/java/com/example/floclone/api/AuthView.kt
+++ b/app/floclone/src/main/java/com/example/floclone/api/AuthView.kt
@@ -1,0 +1,18 @@
+package com.example.floclone.api
+
+interface AuthView {
+
+    // 회원가입 성공 시, 백엔드가 준 SignUpResult 전체를 넘겨줌
+    fun onSignUpSuccess(result: SignUpResult)
+
+    // 회원가입 실패 시, errorMsg에 실패 사유(코드·메시지)를 담아 넘겨줌
+    fun onSignUpFailure(errorMsg: String)
+
+    // 로그인 성공 시, 백엔드가 준 LoginResult 전체를 넘겨줌
+    fun onLoginSuccess(result: LoginResult)
+
+    // 로그인 실패 시, errorMsg에 실패 사유(코드·메시지)를 담아 넘겨줌
+    fun onLoginFailure(errorMsg: String)
+
+
+}

--- a/app/floclone/src/main/java/com/example/floclone/api/NetworkManager.kt
+++ b/app/floclone/src/main/java/com/example/floclone/api/NetworkManager.kt
@@ -5,6 +5,8 @@ import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 
+//실제 API가 있는 서버 주소를 이용해 refrofit 객체를 생성
+
 object NetworkManager {
 
     // 실제 API 서버의 Base URL IN

--- a/app/floclone/src/main/java/com/example/floclone/api/NetworkManager.kt
+++ b/app/floclone/src/main/java/com/example/floclone/api/NetworkManager.kt
@@ -1,0 +1,31 @@
+package com.example.floclone.api
+
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+object NetworkManager {
+
+    // 실제 API 서버의 Base URL IN
+    private const val BASE_URL = "https://aos.inyro.site/"
+    
+    //위의 경우, 실제 각 기능이 실행될 떄, BASE_URL + ApiService에 정의한 URL을 붙여 실행
+
+    
+    //로그로 찾자
+    private val logging = HttpLoggingInterceptor().apply {
+        level = HttpLoggingInterceptor.Level.BODY
+    }
+    private val client = OkHttpClient.Builder()
+        .addInterceptor(logging)
+        .build()
+
+
+    // 1. Retrofit 인스턴스 생성
+    val retrofit: Retrofit = Retrofit.Builder()
+        .baseUrl(BASE_URL)
+        .client(client)
+        .addConverterFactory(GsonConverterFactory.create())
+        .build()
+}

--- a/app/floclone/src/main/java/com/example/floclone/api/Response.kt
+++ b/app/floclone/src/main/java/com/example/floclone/api/Response.kt
@@ -1,0 +1,41 @@
+package com.example.floclone.api
+
+
+//여기서 정의한 데이터 클래스를  ApiService.kt에서 사용
+
+//회원가입 요청 보낼 때 양식
+data class SignUpRequest(
+    val name: String,
+    val email: String,
+    val password: String
+)
+
+//로그인 요청 보낼 때 양식
+data class LoginRequest(
+    val email: String,
+    val password: String
+)
+
+//응답 양식
+data class Response<T> (
+    val isSuccess: Boolean,
+    val code: String,
+    val message: String,
+    val result: T?
+)
+
+//응답 양식 중 회원가입
+data class SignUpResult(
+    val memberId: Long,
+    val createdAt: String,
+    val updatedAt: String
+)
+
+//응답 양식 중 로그인
+data class LoginResult(
+    val memberId: Long,
+    val accessToken: String
+)
+
+typealias LoginResponse = Response<LoginResult>
+typealias SignUpResponse = Response<SignUpResult>


### PR DESCRIPTION
# 📌 [어헛차/#51] 9주차 구현
> Swagger 및 Retrofit을 이용한 로그인/회원가입 기능 구현

## ✅ 변경 사항
- [ ] API를 이용해, 회원 가입 기능 구현
- [ ] API를 이용해, 로그인 기능 구현


## 📷 영상 및 스크린샷
> 작업 내용을 스크린샷 또는 영상 형태로 올려주세요.

https://github.com/user-attachments/assets/5e54c91a-38c2-4e31-a6a6-1e157cd82bca

![image](https://github.com/user-attachments/assets/559e95b5-3413-4064-9d6a-91b3cba4d482)
![image](https://github.com/user-attachments/assets/adcfb970-491c-4c33-91ef-5e4230b498b1)


## 🔗 알게 된 사항
> 이번에 처음으로 API를 다루게 되었는데, Retrofit 객체를 이용한 API 통신 방법에 대해 알게 됨.
> 서버와 연결하기 위해, base url 및 각 기능에 대한 url 탐색 방법 및, json 객체와 data class 연결의 중요성을 알게 됨.


## 📝 질문 사항
> 회원가입을 진행할 경우, Swagger에서 회원가입한 유저의 정보를 볼 수 있는지 궁금합니다.
